### PR TITLE
Update ESLint configuration to force double quotes

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -19,6 +19,10 @@ rules:
   strict: off
   class-methods-use-this: off
   consistent-return: off
+  quotes:
+    - error
+    - double
+    - avoidEscape: true
 overrides:
   - files:
       - "integration/**"

--- a/packages/binary-reader/lib/binary-reader.js
+++ b/packages/binary-reader/lib/binary-reader.js
@@ -17,7 +17,7 @@ class BinaryReader {
       // Otherwise that's an error
       assert(
         _.get(definition, "structures.length") === 1,
-        `No 'structureName' provided: structures.length must be === 1`
+        "No 'structureName' provided: structures.length must be === 1"
       );
       mainStructureName = _.first(definition.structures).name;
     } else {

--- a/packages/definition-reader/__tests__/definition-reader.advanced.test.js
+++ b/packages/definition-reader/__tests__/definition-reader.advanced.test.js
@@ -9,7 +9,7 @@ const pathToFixtures = `${__dirname}/../__fixtures__/`;
 describe("DefinitionReader, advanced", () => {
   // Note: these definitions are not complete at all. They are often inspired by
   // a real-world format but they are never fully implemented.
-  test(`parses example format definition`, () => {
+  test("parses example format definition", () => {
     _.each(["bmp.binr", "mft.binr"], filename => {
       const structure = fs.readFileSync(`${pathToFixtures}/${filename}`, "utf-8");
       const reader = new DefinitionReader();

--- a/packages/definition-reader/__tests__/definition-reader.test.js
+++ b/packages/definition-reader/__tests__/definition-reader.test.js
@@ -116,7 +116,7 @@ describe("DefinitionReader", () => {
   });
 
   test("accepts == and ||", () => {
-    const result = createAndCallParser(`struct a { int foo[1 == 2 || 3 == 4]; }`)();
+    const result = createAndCallParser("struct a { int foo[1 == 2 || 3 == 4]; }")();
     expect(result).toBeDefined();
     const resultFn = _.first(_.first(result.structures).statements).type.sizeExpression;
     expect(resultFn).toBeDefined();

--- a/packages/definition-reader/lib/definition-lexer.js
+++ b/packages/definition-reader/lib/definition-lexer.js
@@ -142,7 +142,7 @@ const keywordTokens = _.fromPairs(
       If: "if",
       Else: "else",
       Until: "until",
-      Switch: "switch"
+      Switch: "switch",
     },
     (keyword, name) => [
       `${name}Token`,

--- a/packages/definition-reader/lib/definition-reader.js
+++ b/packages/definition-reader/lib/definition-reader.js
@@ -46,7 +46,9 @@ class DefinitionReader {
 
     if (!_.isEmpty(parser.errors)) {
       const firstError = _.first(parser.errors);
-      const message = `${firstError.name}: ${firstError.message} (token ${firstError.token.image} at ${firstError.token.startLine}:${firstError.token.startColumn})`;
+      const tokenPosition = `${firstError.token.startLine}:${firstError.token.startColumn}`;
+      const tokenDetails = `(token ${firstError.token.image} at ${tokenPosition})`;
+      const message = `${firstError.name}: ${firstError.message} ${tokenDetails}`;
       throw new Error(`Got an error while parsing input: ${message}`);
     }
 

--- a/packages/definition-reader/lib/expression-converter.js
+++ b/packages/definition-reader/lib/expression-converter.js
@@ -14,14 +14,14 @@ class ExpressionConverter {
   convert(source) {
     const ast = esprima.parseScript(source);
     if (!_.isArray(ast.body)) {
-      throw new Error(`AST body is not an array`);
+      throw new Error("AST body is not an array");
     }
     if (_.size(ast.body) !== 1) {
-      throw new Error(`AST body size shall be 1`);
+      throw new Error("AST body size shall be 1");
     }
     const bodyExpression = ast.body[0];
     if (bodyExpression.type !== esprima.Syntax.ExpressionStatement) {
-      throw new Error(`body shall be an expression`);
+      throw new Error("body shall be an expression");
     }
     bodyExpression.expression = this.processExpression(bodyExpression.expression);
     const generatedSource = escodegen.generate(ast);
@@ -33,7 +33,7 @@ class ExpressionConverter {
       return expression;
     }
     if (expression.type === esprima.Syntax.UpdateExpression) {
-      throw new Error(`UpdateExpression not supported`);
+      throw new Error("UpdateExpression not supported");
     }
     if (expression.type === esprima.Syntax.Identifier) {
       return this.generateVariableScopeGetNode(expression.name);


### PR DESCRIPTION
Instead of mixing styles in the code base, the ESLint configuration
has been updated to force the quote style.